### PR TITLE
NeuralNetworkResamplerのモデル読み込みを外部化

### DIFF
--- a/prepare_release.py
+++ b/prepare_release.py
@@ -45,7 +45,7 @@ PY_FILES = [
     'util.py',
 ]
 
-OTHRER_FILES = [
+OTHER_FILES = [
     'LICENSE',
     'README.md',
     'requirements.txt',
@@ -58,9 +58,9 @@ def install_torch_cpu():
     """
     python_exe = str(PYTHON_DIR / 'python.exe')
     uninstall_command = [python_exe, '-m', 'pip', 'uninstall', '-y', 'torch', 'torchvision', 'torchaudio', '--no-input']  # fmt: skip
-    subprocess.run(uninstall_command, check=True, shell=True)  # noqa: S603
+    subprocess.run(uninstall_command, check=True)  # noqa: S603
     install_command = [python_exe, '-m', 'pip', 'install', 'torch', 'torchvision', 'torchaudio', '--no-warn-script-location']  # fmt: skip
-    subprocess.run(install_command, check=True, shell=True)  # noqa: S603
+    subprocess.run(install_command, check=True)  # noqa: S603
 
 
 def remove_cache_files(path_dir: Path):
@@ -97,7 +97,7 @@ def prepare_release(version: str):
     print('──────────────────────────────────────────────')
 
     # 必要なファイルをコピーする
-    required_files = EXE_FILES + BAT_FILES + CS_FILES + PY_FILES + OTHRER_FILES
+    required_files = EXE_FILES + BAT_FILES + CS_FILES + PY_FILES + OTHER_FILES
     for fname in required_files:
         print(f'Copying file: {fname}')
         shutil.copy2(SOURCE_DIR / fname, release_dir / fname)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ git+https://github.com/oatsu-gh/HN-UnifiedSourceFilterGAN@kuresampler
 numpy<2
 omegaconf
 light-the-torch
+colored-traceback
 # torch should be installed manually according to the environment


### PR DESCRIPTION
## 概要
- `resampler.py` のボコーダーモデル処理を改善
- `resampler.py` のコード整理
- `prepare_release.py` の軽微な修正

### ボコーダーモデル処理の改善
* `NeuralNetworkResamp` クラスで、ディレクトリパスではなくボコーダーモデルオブジェクトを直接受け取るよう変更し、適切な検証とエラーハンドリングを追加。
* `main_resampler` 関数をリファクタリングし、引数解析を改善。必要な場合のみボコーダーモデルを読み込むよう最適化。
* ログメッセージを改善し、WORLD またはニューラルボコーダーの使用状況をより明確に表示。

### コードの整理
* `NeuralNetworkResamp` クラスで、未使用のインポートや関数（`return_features`、`return_waveform`）を削除
* `NeuralNetworkResamp` クラスで、不要になった `vocoder_model_dir` 属性と関連ロジックを削除
* ほか、不要な import を削除

### その他の修正
* `prepare_release.py` で変数名のタイポを修正（`OTHRER_FILES` → `OTHER_FILES`）
* `subprocess.run` から `shell=True` を削除してセキュリティを向上