### PR TITLE
Segmented synthesis

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -520,4 +520,8 @@ def world_to_nnsvs_to_waveform(
         vuv_threshold=vuv_threshold,
     )
 
+    # GPUメモリ開放
+    if str(device) == 'cuda':
+        torch.cuda.empty_cache()
+
     return waveform  # vocoder_sample_rate

--- a/exe/test_child.bat
+++ b/exe/test_child.bat
@@ -19,8 +19,10 @@
 @set python_exe=python
 @set python_script=%ROOT%unified_engine.py
 @set model_dir=%ROOT%models\usfGAN_EnunuKodoku_0826\
+@REM @set model_dir=%ROOT%models\usfGAN_NamineRitsu_4130\
 
 @REM Run python script if output file does not exist
-@%python_exe% %python_script% %* --model_dir %model_dir% --use_vocoder_model --debug
+@%python_exe% %python_script% %* --model_dir %model_dir% --use_vocoder_model
+@REM @%python_exe% %python_script% %* --model_dir %model_dir% --use_vocoder_model --debug
 @REM @echo =============================================================================
-PAUSE
+@REM PAUSE

--- a/exe/test_child.bat
+++ b/exe/test_child.bat
@@ -22,7 +22,7 @@
 @REM @set model_dir=%ROOT%models\usfGAN_NamineRitsu_4130\
 
 @REM Run python script if output file does not exist
-@%python_exe% %python_script% %* --model_dir %model_dir% --use_vocoder_model
-@REM @%python_exe% %python_script% %* --model_dir %model_dir% --use_vocoder_model --debug
+@REM @%python_exe% %python_script% %* --model_dir %model_dir% --use_vocoder_model
+@%python_exe% %python_script% %* --model_dir %model_dir% --use_vocoder_model --debug
 @REM @echo =============================================================================
-@REM PAUSE
+PAUSE

--- a/kuresampler.py
+++ b/kuresampler.py
@@ -277,6 +277,8 @@ class NeuralNetworkRender(Render):
             wavtool.append()
             # WAV生成
             wavtool.synthesize()
+            wavtool.save_wav()
+            wavtool.save_npz()
             self.logger.debug('Exported WAV: %s', out_wav_path)
 
     def clean(self) -> None:

--- a/unified_engine.py
+++ b/unified_engine.py
@@ -657,7 +657,7 @@ def segmented_wavtool(
     if not (len(waveform_list) == len(overlap_list) == len(residual_error_list)):
         msg = (
             f'Length of waveform_list ({len(waveform_list)}) and '
-            f'adjusted_overlap_list ({len(overlap_list)}) and '
+            f'overlap_list ({len(overlap_list)}) and '
             f'residual_error_list ({len(residual_error_list)}) do not match.'
         )
         raise ValueError(msg)

--- a/unified_engine.py
+++ b/unified_engine.py
@@ -676,8 +676,8 @@ def segmented_wavtool(
             unit='seg',
         ):
             # オーバーラップ値を補正する
-            ## residual_error が正の時は wav が短めなので、次の休符とのoverlapを短くする。
-            ## residual_error が負の時は wav が長めなので、次の休符とのoverlapを長くする。
+            ## residual_error が正の時は wav が短めなので、次のセグメントとのoverlapを短くする。
+            ## residual_error が負の時は wav が長めなので、次のセグメントとのoverlapを長くする。
             adjusted_overlap = seg_overlap - residual_error
             residual_error = seg_res_err
             logger.debug('Overlapping waveforms with overlap: %.3f [ms]', adjusted_overlap)
@@ -828,11 +828,19 @@ def main():
         vocoder_config=vocoder_config,
         target_sample_rate=sample_rate,
     )
+    tqdm.write(f'Final residual error after segmented wavtool: {last_residual_error:.3f} [ms]')
+    tqdm.write(
+        f'Final waveform length: {len(waveform)} samples ({len(waveform) / sample_rate:.3f} sec)'
+    )
     # 最終セグメントの長さずれの分だけサンプル数を補正する
     waveform = fix_waveform_length(
         waveform,
         last_residual_error,
         sample_rate=sample_rate,
+    )
+    tqdm.write(
+        f'Waveform length after length fix: {len(waveform)} samples '
+        f'({len(waveform) / sample_rate:.3f} sec)'
     )
     # WAV ファイル出力
     waveform_to_wavfile(

--- a/unified_engine.py
+++ b/unified_engine.py
@@ -16,49 +16,55 @@ temp_helper.bat の内容
 @"%tool%" "%output%" %temp% %stp% %3 %env%
 ---------------------
 """
-
 import argparse
+import functools
 import logging
 import os
 import shlex
 import sys
+from copy import copy
 from logging import INFO, Logger
 from pathlib import Path
 from pprint import pprint
 from warnings import warn
 
 import colored_traceback.auto  # noqa: F401
+import librosa
 import numpy as np
 import torch
 from nnsvs.util import StandardScaler
 from omegaconf.dictconfig import DictConfig
 from omegaconf.listconfig import ListConfig
-from tqdm.contrib import tenumerate
+from tqdm import tqdm
+from tqdm.contrib import tzip
 from tqdm.contrib.concurrent import thread_map
+from tqdm.contrib.logging import logging_redirect_tqdm
 
 if __name__ == '__main__':
     sys.path.append(str(Path(__file__).parent))  # for local import
+from convert import waveform_to_wavfile
 from resampler import NeuralNetworkResamp
-from util import load_vocoder_model, setup_logger, str2float
+from util import fade_waveform, load_vocoder_model, overlap_waveform, setup_logger, str2float
 from wavtool import NeuralNetworkWavTool
 
 TEMP_BAT = Path('temp.bat')
 TEMP_WAV = Path('temp.wav')
 TEMP_NPZ = Path('temp.npz')
 DEFAULT_ENCODING = 'cp932'
-MAX_WORKERS = os.cpu_count() or 1
+DEFAULT_DTYPE = 'float64'
+MAX_WORKERS = (os.cpu_count() or 1) * 2
 
-def i_am_the_first(temp_wav_path: Path = TEMP_WAV) -> bool:
+def i_am_the_first(wav_path: Path) -> bool:
     """自分が1番目の処理なのかそれ以外なのかを判定する。
 
     判定方法: temp.wav があるかどうかで判定
     """
     # すでに temp.wav が存在する場合は、2番目以降の処理と判定して False を返す。
-    if temp_wav_path.exists():
+    if wav_path.exists():
         return False
     # temp.wav が存在しない場合は1番目の処理と判断して、
     # True を返すとともに、ダミーwavを生成する。
-    temp_wav_path.touch()
+    wav_path.touch()
     return True
 
 
@@ -304,23 +310,243 @@ def batch_resampler(
     logger.setLevel(logging.WARNING)
 
     # マルチプロセスで resampler を実行
-    thread_map(
-        _process_resampler_command,
-        commands_with_logger,
-        desc='Resampler',
-        unit='note',
-        colour='green',
-        chunksize=1,
-        mininterval=0,
-        max_workers=max_workers,
-    )
+    with logging_redirect_tqdm([logger]):
+        thread_map(
+            _process_resampler_command,
+            commands_with_logger,
+            desc='Resampler',
+            unit='note',
+            colour='green',
+            chunksize=1,
+            mininterval=0,
+            max_workers=max_workers,
+        )
     # logger レベルを元に戻す
     logger.setLevel(original_log_level)
 
 
-def batch_wavetool(
+def generate_silent_waveform(duration_ms: float, sample_rate: int, dtype='float64') -> np.ndarray:
+    """指定された長さの無音波形を生成する。
+
+    Args:
+        duration_ms: 無音の長さ[ms]
+        sample_rate: サンプリングレート[Hz]
+        dtype: waveform のデータ型
+
+    Returns:
+        無音波形 (np.ndarray)
+
+    """
+    num_samples = int(duration_ms * sample_rate / 1000)
+    return np.zeros(num_samples, dtype=dtype)
+
+
+def batch_wavtool(
+    wavtool_commands: list[list[str]],
+    *,
     logger: Logger,
-    wavetool_commands: list[list[str]],
+    use_vocoder_model: bool,
+    frame_period: int = 5,
+    vocoder_model: torch.nn.Module | None = None,
+    vocoder_in_scaler: StandardScaler | None = None,
+    vocoder_config: DictConfig | ListConfig | None = None,
+    vocoder_type: str = 'usfgan',
+    vocoder_feature_type: str = 'world',
+    vocoder_vuv_threshold: float = 0.5,
+    vocoder_frame_period: int = 5,
+    internal_sample_rate: int = 48000,
+    target_sample_rate: int = 44100,
+    resample_type: str = 'soxr_vhq',
+    dtype: str = DEFAULT_DTYPE,
+) -> tuple[np.ndarray, float, float]:
+    """wavetool_commands に基づいて wavtool を順次実行する。
+
+    コマンドの例
+    -----------------------
+    <tool> <output> <temp> <stp> <length> <envelope>
+    -----------------------
+        tool   : wavtool.exe など実行ファイルのパス
+        output : 出力wavファイルパス
+        temp   : 入力wavファイルパス
+        stp    : 入力wav使用開始位置[ms]
+        length : ノート長さ[ms]
+        env    : 音量エンベロープのパラメータ (複数可)
+
+    """
+    # ノート数
+    n_notes = len(wavtool_commands)
+    # wavtool インスタンス保持用の変数
+    wavtool: NeuralNetworkWavTool
+    # ノート時刻の丸め誤差
+    residual_error: float = 0.0
+    # メモリ上で累積特徴量を保持 (ファイルI/Oを減らすため)
+    accumulated_features: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None
+
+    # ノート数が 0 の時は何もしないで空の値を返す
+    if n_notes == 0:
+        msg = 'wavtool に渡されるノート数が 0 です。'
+        raise ValueError(msg)
+    # 各ノートのパラメータを格納するリスト
+    overlap_list: list[float] = []
+    residual_error_list: list[float] = []
+
+    # 各ノートのwav加工を行う
+    with logging_redirect_tqdm([logger]):
+        for cmd in tqdm(
+            wavtool_commands,
+            mininterval=0,
+            desc='WavTool',
+            unit='note',
+            colour='blue',
+        ):
+            try:
+                logger.debug(cmd)
+                if len(cmd) < 6:
+                    logger.error(
+                        f'Number of wavtool arguments must be 6 or larger ({len(cmd)}): {cmd}'
+                    )
+                    continue
+                (
+                    output_path,
+                    input_path,
+                    stp,
+                    length,
+                    *envelope,
+                ) = cmd[1:]  # cmd[0] は wavtool の実行ファイルパス
+
+                length_ms = str2float(length)
+
+                # 各パラメータをログ出力
+                logger.debug(f'  output_path  : {Path(output_path).name}')
+                logger.debug(f'  input_path   : {Path(input_path).name}')
+                logger.debug(f'  stp          : {stp}')
+                logger.debug(f'  length (str) : {length}')
+                logger.debug(f'  length (ms)  : {length_ms} [ms]')
+                logger.debug(f'  envelope     : {envelope}')
+
+                logger.debug('residual_error (before wavtool) : %.3f [ms]', residual_error)
+                # wavtool インスタンスを生成
+                wavtool = NeuralNetworkWavTool(
+                    output_wav=output_path,
+                    input_wav=input_path,
+                    stp=float(stp),
+                    length=length_ms,
+                    envelope=list(map(float, envelope)),
+                    logger=logger,
+                    use_vocoder_model=use_vocoder_model,
+                    frame_period=frame_period,
+                    residual_error=residual_error,
+                    vocoder_model=vocoder_model,
+                    vocoder_in_scaler=vocoder_in_scaler,
+                    vocoder_config=vocoder_config,
+                    vocoder_type=vocoder_type,
+                    vocoder_feature_type=vocoder_feature_type,
+                    vocoder_vuv_threshold=vocoder_vuv_threshold,
+                    vocoder_frame_period=vocoder_frame_period,
+                    internal_sample_rate=internal_sample_rate,
+                    target_sample_rate=target_sample_rate,
+                    resample_type=resample_type,
+                    accumulated_features=accumulated_features,
+                )
+                residual_error = wavtool.residual_error
+                logger.debug('residual_error (after wavtool)  : %.3f [ms]', residual_error)
+
+                # wavtool を実行
+                wavtool.append()
+                # メモリ上で累積特徴量を更新
+                accumulated_features = (
+                    wavtool.f0_appended,
+                    wavtool.sp_appended,
+                    wavtool.ap_appended,
+                )
+                # 各ノートのオーバーラップ長[ms]を保存
+                overlap_list.append(wavtool.overlap)
+                # 各ノートの residual_error[ms] を保存
+                residual_error_list.append(residual_error)
+            except Exception as e:
+                logger.critical(f'Exception occurred for the note: {cmd}')
+                raise e
+
+    # 最終ノートの wavtool が持っている特徴量と wav を保存
+    if accumulated_features is None:
+        msg = 'accumulated_features is None after wavtool processing.'
+        raise RuntimeError(msg)
+    logger.debug('Synthesizing waveform...')
+    logger.debug(f'Accumulated features shape: {[feat.shape for feat in accumulated_features]}')
+
+    # 特徴量の要素数が0の場合は waveform で空のndarrayを返す
+    if accumulated_features[0].shape[0] == 0:
+        logger.debug('No features to synthesize. Returning empty waveform.')
+        return np.array([], dtype=DEFAULT_DTYPE), overlap_list[0], residual_error_list[-1]
+
+    # 無音かどうかの判定
+    sp_appended = accumulated_features[1]
+    seg_is_silence = sp_appended.sum() == 0.0
+    # 特徴量の要素数が0ではないが無音の場合は、ボコーダーを通さずに完全な無音のwaveformを生成する
+    if seg_is_silence:
+        total_duration_ms = sp_appended.shape[0] * frame_period
+        logger.debug(
+            'This segment is a silence. Generating silent waveform (%.3f ms).',
+            total_duration_ms,
+        )
+        silent_waveform = generate_silent_waveform(
+            duration_ms=total_duration_ms,
+            sample_rate=target_sample_rate,
+            dtype=DEFAULT_DTYPE,
+        )
+        resampled_waveform = silent_waveform
+        first_overlap_ms = overlap_list[0]
+        last_residual_error_ms = residual_error_list[-1]
+
+    # 特徴量の要素数が0ではないかつ無音ではない場合は、ボコーダーでwaveformを合成する
+    else:
+        wavtool.synthesize()  # pyright: ignore[reportPossiblyUnboundVariable]
+        logger.debug('Synthesis complete.')
+
+        # 結合された特徴量をもとに生成した waveform
+        waveform = copy(wavtool.waveform)  # pyright: ignore[reportPossiblyUnboundVariable]
+        resampled_waveform = librosa.resample(
+            waveform,
+            orig_sr=internal_sample_rate,
+            target_sr=target_sample_rate,
+            res_type=resample_type,
+        )
+        first_overlap_ms = overlap_list[0]
+        last_residual_error_ms = residual_error_list[-1]
+
+    # 生成した waveform と 音声長の誤差[ms] を返す
+    return resampled_waveform.astype(dtype), first_overlap_ms, last_residual_error_ms
+
+
+def fix_waveform_length(
+    waveform: np.ndarray, residual_error_ms: float, sample_rate: int
+) -> np.ndarray:
+    """Waveform の長さを residual_error_ms に基づいて修正する。
+
+    Args:
+        waveform: 入力波形
+        residual_error_ms: 波形長の誤差[ms]
+        sample_rate: サンプリングレート[Hz]
+
+    Returns:
+        修正後の波形
+
+    """
+    num_error_samples = round(residual_error_ms * sample_rate / 1000)
+    # wav が目標よりも短い場合はゼロパディングする。
+    if num_error_samples > 0:
+        waveform = np.pad(waveform, (0, num_error_samples))
+    # wav が目標よりも長い場合は切り詰める。
+    elif num_error_samples < 0:
+        waveform = waveform[:num_error_samples]
+    else:
+        pass  # 誤差なし
+    return waveform
+
+
+def segmented_wavtool(
+    logger: Logger,
+    wavtool_commands: list[list[str]],
     *,
     use_vocoder_model: bool,
     frame_period: int = 5,
@@ -335,111 +561,155 @@ def batch_wavetool(
     target_sample_rate: int = 44100,
     resample_type: str = 'soxr_vhq',
 ):
-    """wavetool_commands に基づいて wavtool を順次実行する。
+    """休符ごとにwav生成して最後につなげる。
 
-    コマンドの例
+    wavtool コマンドの例
     -----------------------
-    @"%tool%" "%output%" %temp% %stp% %3 %env%
+    <tool> <output> <temp> <stp> <length> <envelope>
     -----------------------
 
     """
-    # 一時ファイルを削除
-    TEMP_NPZ.unlink(missing_ok=True)
-    n_notes = len(wavetool_commands)
-    # ノート時刻の丸め誤差
-    residual_error: float = 0.0
-    # メモリ上で累積特徴量を保持 (ファイルI/Oを減らすため)
-    accumulated_features: tuple[np.ndarray, np.ndarray, np.ndarray] | None = None
+    # 各ノートの入力ファイルの有無
+    is_silence_note_list: list[bool] = [(not Path(cmd[2]).exists()) for cmd in wavtool_commands]
 
-    # ログ出力抑制
-    original_log_level = logger.level
-    logger.setLevel(logging.WARNING)
-    # 各ノートのwav加工を行う
-    for i, cmd in tenumerate(
-        wavetool_commands,
-        mininterval=0,
-        desc='WavTool',
-        unit='note',
-        colour='blue',
-    ):
-        logger.debug(cmd)
-        if len(cmd) < 6:
-            logger.error(f'Number of wavtool arguments must be 6 or larger ({len(cmd)}): {cmd}')
-            continue
-        (
-            output_path,
-            input_path,
-            stp,
-            length,
-            *envelope,
-        ) = cmd[1:]  # cmd[0] は wavtool の実行ファイルパス
+    # 休符で区切ってセグメントを作成
+    segment_list: list[list[list[str]]] = []
+    is_silent_segment_list: list[bool] = []
+    current_segment: list[list[str]] = []
 
-        length_ms = str2float(length)
+    # ノートを休符区切りでグループ化してセグメントにする。
+    # 休符が出現したり、休符の後に音符が出現したらセグメントを区切る
+    with logging_redirect_tqdm([logger]):
+        for cmd, current_note_is_silence in tzip(
+            wavtool_commands,
+            is_silence_note_list,
+            mininterval=0,
+            desc='Segmenting',
+            unit='note',
+            colour='cyan',
+        ):
+            # 休符や無音の場合は、セグメントを切り替える
+            if current_note_is_silence:
+                logger.debug('********* 休符です!!!! ***********')
+                # 既存セグメントが空でない場合
+                if len(current_segment) > 0:
+                    is_silent_segment_list.append(False)
+                    segment_list.append(current_segment)
+                # 休符自身単体をセグメントのリストに追加し、次ノートのために新規セグメントを開始
+                is_silent_segment_list.append(True)
+                segment_list.append([cmd])
+                current_segment = []
+            # 音符の場合はセグメントに追加
+            else:
+                current_segment.append(cmd)
 
-        # 各パラメータをログ出力
-        logger.debug(f'  output_path  : {Path(output_path).name}')
-        logger.debug(f'  input_path   : {Path(input_path).name}')
-        logger.debug(f'  stp          : {stp}')
-        logger.debug(f'  length (str) : {length}')
-        logger.debug(f'  length (ms)  : {length_ms} [ms]')
-        logger.debug(f'  envelope     : {envelope}')
+    # ループ後に残ったセグメントをリストに追加
+    if current_segment:
+        is_silent_segment_list.append(False)
+        segment_list.append(current_segment)
 
-        logger.debug('residual_error (before wavtool) : %.3f [ms]', residual_error)
-        # wavtool インスタンスを生成
-        wavtool = NeuralNetworkWavTool(
-            output_wav=output_path,
-            input_wav=input_path,
-            stp=float(stp),
-            length=length_ms,
-            envelope=list(map(float, envelope)),
-            logger=logger,
-            use_vocoder_model=use_vocoder_model,
-            frame_period=frame_period,
-            residual_error=residual_error,
-            vocoder_model=vocoder_model,
-            vocoder_in_scaler=vocoder_in_scaler,
-            vocoder_config=vocoder_config,
-            vocoder_type=vocoder_type,
-            vocoder_feature_type=vocoder_feature_type,
-            vocoder_vuv_threshold=vocoder_vuv_threshold,
-            vocoder_frame_period=vocoder_frame_period,
-            internal_sample_rate=internal_sample_rate,
-            target_sample_rate=target_sample_rate,
-            resample_type=resample_type,
-            accumulated_features=accumulated_features,
+    # セグメントのリストの要素数をチェック
+    if len(segment_list) != len(is_silent_segment_list):
+        msg = (
+            f'lengths of segment_list ({len(segment_list)}) '
+            f'and is_silent_segment_list ({len(is_silent_segment_list)}) do not match.'
         )
-        residual_error = wavtool.residual_error
-        logger.debug('residual_error (after wavtool)  : %.3f [ms]', residual_error)
+        raise ValueError(msg)
 
-        # wavtool を実行
-        wavtool.append()
-        # メモリ上で累積特徴量を更新
-        accumulated_features = (
-            wavtool.f0_appended,
-            wavtool.sp_appended,
-            wavtool.ap_appended,
+    # セグメント状態をログ出力
+    logger.info(f'Total segments: {len(segment_list)}')
+    logger.debug(f'Note count in each segment        : {[len(seg) for seg in segment_list]}')
+    logger.debug(f'Silence or non-silence of segment : {is_silent_segment_list}')
+
+    # 部分関数を作成
+    partial_batch_wavtool = functools.partial(
+        batch_wavtool,
+        logger=logger,
+        use_vocoder_model=use_vocoder_model,
+        frame_period=frame_period,
+        vocoder_model=vocoder_model,
+        vocoder_in_scaler=vocoder_in_scaler,
+        vocoder_config=vocoder_config,
+        vocoder_type=vocoder_type,
+        vocoder_feature_type=vocoder_feature_type,
+        vocoder_vuv_threshold=vocoder_vuv_threshold,
+        vocoder_frame_period=vocoder_frame_period,
+        internal_sample_rate=internal_sample_rate,
+        target_sample_rate=target_sample_rate,
+        resample_type=resample_type,
+    )
+
+    # セグメントごとに waveform を生成してリストに格納
+    # TODO: 休符セグメントは無音波形を生成する。overlap と residual_error に注意。
+    waveform_list: list[np.ndarray] = []
+    residual_error_list: list[float] = []
+    overlap_list: list[float] = []
+    with logging_redirect_tqdm([logger]):
+        for seg_commands in tqdm(
+            segment_list, desc='Synthesizing wav segments', unit='seg', colour='magenta'
+        ):
+            wav, first_overlap, last_residual_error = partial_batch_wavtool(seg_commands)
+            waveform_list.append(wav)
+            overlap_list.append(first_overlap)
+            residual_error_list.append(last_residual_error)
+
+    # zip ループを回す前に要素数チェック
+    if not (len(waveform_list) == len(overlap_list) == len(residual_error_list)):
+        msg = (
+            f'Length of waveform_list ({len(waveform_list)}) and '
+            f'adjusted_overlap_list ({len(overlap_list)}) and '
+            f'residual_error_list ({len(residual_error_list)}) do not match.'
         )
-
-        # 最終ノートの時のみ npz と wav を出力
-        if i == n_notes - 1:
-            logger.setLevel(original_log_level)
-            logger.info('Rendering WAV...')
-            wavtool.synthesize()
-            logger.info('Render complete.')
-
+        raise ValueError(msg)
+    # 各セグメントの waveform をつなげる
+    long_waveform: np.ndarray = waveform_list[0]
+    adjusted_overlap: float = overlap_list[0]
+    residual_error: float = residual_error_list[0]
+    with logging_redirect_tqdm([logger]):
+        for seg_wav, seg_overlap, seg_res_err in tzip(
+            waveform_list[1:],
+            overlap_list[1:],
+            residual_error_list[1:],
+            mininterval=0,
+            colour='red',
+            desc='Concatenating waveform segments',
+            unit='seg',
+        ):
+            # オーバーラップ値を補正する
+            ## residual_error が正の時は wav が短めなので、次の休符とのoverlapを短くする。
+            ## residual_error が負の時は wav が長めなので、次の休符とのoverlapを長くする。
+            adjusted_overlap = seg_overlap - residual_error
+            residual_error = seg_res_err
+            logger.debug('Overlapping waveforms with overlap: %.3f [ms]', adjusted_overlap)
+            logger.debug('Waveform shapes: %s, %s', long_waveform.shape, seg_wav.shape)
+            # waveform の長さが0の場合はスキップする
+            if len(seg_wav) == 0:
+                logger.debug('Skipping empty segment waveform.')
+                # オーバーラップが行われないことでずれるので次のノートの引き継がせる
+                # 次のノートのオーバーラップを長くしないといけない -> res_error を小さくする
+                residual_error = seg_res_err - adjusted_overlap
+                continue
+            # 微小なフェードインとフェードアウトを行う
+            faded_seg_wav = fade_waveform(
+                seg_wav,
+                fade_in_ms=frame_period,
+                fade_out_ms=frame_period,
+                sample_rate=target_sample_rate,
+            )
+            # waveform をオーバーラップさせて結合する
+            long_waveform = overlap_waveform(
+                long_waveform,
+                faded_seg_wav,
+                overlap_ms=adjusted_overlap,
+                sample_rate=target_sample_rate,
+            )
+    # 最終的な waveform を返す
+    return long_waveform, adjusted_overlap, residual_error
 
 # noqa: T201
 def main():
     """全体の処理を行う。"""
-    print(sys.argv)
-    # 2番目以降の処理の場合
-    if not i_am_the_first():
-        print("I'm not the first process. Just passing through.")
-        return
-
-    # 1番目の処理の場合
-    print('\nI am the first process!')
-    logger = setup_logger(INFO)
+    pprint(sys.argv)
 
     parser = argparse.ArgumentParser(description='UTAU wavtool crossfading WORLD features')
     # 中間のコマンドライン引数は無視
@@ -471,10 +741,22 @@ def main():
         default=False,
     )
     args = parser.parse_args()
+    logger = setup_logger(INFO)
 
     # デバッグモード
     if args.debug:
         logger.setLevel(logging.DEBUG)
+
+    # temp.bat を解析して変数とコマンドを取得
+    bat_variables, resamp_commands, wavtool_commands = parse_temp_bat()
+    # バッチファイル内の変数を取得
+    sample_rate = int(bat_variables.get('samples', 44100))
+    wav_out_path = Path(bat_variables.get('output', TEMP_WAV))
+    npz_out_path = wav_out_path.with_suffix('.npz')
+    # 2番目以降の処理の場合
+    if not i_am_the_first(wav_out_path):
+        print("I'm not the first process. Just passing through.")
+        return
 
     # ボコーダーモデルを使用するか否か
     use_vocoder_model = args.use_vocoder_model
@@ -491,14 +773,13 @@ def main():
         vocoder_in_scaler = None
         vocoder_config = None
 
-    variables, resamp_commands, wavtool_commands = parse_temp_bat()
     # helper.bat の内容を空にする
-    helper_path = Path(variables.get('helper', 'helper.bat'))
+    helper_path = Path(bat_variables.get('helper', 'helper.bat'))
     clear_helper_bat(helper_path)
 
     if args.debug:
         print('\nVariables:')
-        pprint(variables)
+        pprint(bat_variables)
         print(f'\nResampler commands ({len(resamp_commands)}):')
         pprint(resamp_commands, compact=True)
         print(f'\nWavTool commands ({len(wavtool_commands)}):')
@@ -508,14 +789,57 @@ def main():
     # resampler を順次実行する
     batch_resampler(logger, resamp_commands)
     print('------------------------------------')
-    # wavtool を順次実行する
-    batch_wavetool(
+
+    # 一時ファイルを削除
+    wav_out_path.unlink(missing_ok=True)
+    npz_out_path.unlink(missing_ok=True)
+
+    # wavtool を順次実行する(一括版)
+    # waveform, _first_overlap, last_residual_error = batch_wavtool(
+    #     wavtool_commands,
+    #     logger=logger,
+    #     use_vocoder_model=use_vocoder_model,
+    #     vocoder_model=vocoder_model,
+    #     vocoder_in_scaler=vocoder_in_scaler,
+    #     vocoder_config=vocoder_config,
+    #     target_sample_rate=sample_rate,
+    # )
+    # # 最終的な長さずれ分のサンプル数を補正する
+    # waveform = fix_waveform_length(
+    #     waveform,
+    #     last_residual_error,
+    #     sample_rate=sample_rate,
+    # )
+    # # WAV ファイル出力
+    # waveform_to_wavfile(
+    #     waveform,
+    #     wav_out_path,
+    #     original_sample_rate=sample_rate,
+    #     target_sample_rate=sample_rate,
+    # )
+
+    # segmented wavtool を実行する (セグメント版)
+    waveform, _first_overlap, last_residual_error = segmented_wavtool(
         logger,
         wavtool_commands,
         use_vocoder_model=use_vocoder_model,
         vocoder_model=vocoder_model,
         vocoder_in_scaler=vocoder_in_scaler,
         vocoder_config=vocoder_config,
+        target_sample_rate=sample_rate,
+    )
+    # 最終セグメントの長さずれの分だけサンプル数を補正する
+    waveform = fix_waveform_length(
+        waveform,
+        last_residual_error,
+        sample_rate=sample_rate,
+    )
+    # WAV ファイル出力
+    waveform_to_wavfile(
+        waveform,
+        wav_out_path,
+        original_sample_rate=sample_rate,
+        target_sample_rate=sample_rate,
     )
     print('----------------- END -------------------')
 

--- a/unified_engine.py
+++ b/unified_engine.py
@@ -22,7 +22,6 @@ import logging
 import os
 import shlex
 import sys
-from copy import copy
 from logging import INFO, Logger
 from pathlib import Path
 from pprint import pprint
@@ -504,7 +503,7 @@ def batch_wavtool(
         logger.debug('Synthesis complete.')
 
         # 結合された特徴量をもとに生成した waveform
-        waveform = copy(wavtool.waveform)  # pyright: ignore[reportPossiblyUnboundVariable]
+        waveform = wavtool.waveform.copy()  # pyright: ignore[reportPossiblyUnboundVariable]
         resampled_waveform = librosa.resample(
             waveform,
             orig_sr=internal_sample_rate,

--- a/util.py
+++ b/util.py
@@ -60,7 +60,7 @@ def setup_logger(level=logging.INFO) -> logging.Logger:
         '[%(filename)s:%(lineno)d][%(log_color)s%(levelname)s%(reset)s] %(message)s',
         log_colors={
             'DEBUG': 'green',
-            'INFO': 'blue',
+            'INFO': 'cyan',
             'WARNING': 'yellow',
             'ERROR': 'red',
             'CRITICAL': 'red,bg_white',
@@ -444,6 +444,72 @@ def overlap_ap(
     )
     return result
 
+def overlap_waveform(
+    wav_a: np.ndarray,
+    wav_b: np.ndarray,
+    *,
+    overlap_ms: float,
+    sample_rate: int,
+) -> np.ndarray:
+    """波形を単純オーバーラップさせる。"""
+    ## 入力チェック
+    # 型が一致するかチェック
+    if wav_a.dtype != wav_b.dtype:
+        msg = f'Waveform dtype mismatch: wav_a.dtype={wav_a.dtype}, wav_b.dtype={wav_b.dtype}'
+        raise ValueError(msg)
+    # 波形が1次元配列かチェック
+    if wav_a.ndim != 1 or wav_b.ndim != 1:
+        msg = f'Waveform must be 1D array. Got wav_a.ndim={wav_a.ndim}, wav_b.ndim={wav_b.ndim}'
+        raise ValueError(msg)
+    # オーバーラップ部分のサンプル数
+    n_overlap = int(overlap_ms * sample_rate / 1000)
+
+    # オーバーラップが 0 の場合は単純結合
+    if n_overlap == 0:
+        result = np.concatenate([wav_a, wav_b], axis=0)
+    # オーバーラップが正の場合はオーバーラップ部分を加算
+    elif n_overlap > 0:
+        result = np.concatenate(
+            [
+                wav_a[:-n_overlap],
+                wav_a[-n_overlap:] + wav_b[:n_overlap],
+                wav_b[n_overlap:],
+            ],
+            axis=0,
+        )
+    # オーバーラップが負の場合は間に無音を挟む
+    else:
+        result = np.concatenate(
+            [
+                wav_a,
+                np.zeros(-n_overlap, dtype=wav_a.dtype),
+                wav_b,
+            ],
+            axis=0,
+        )
+    return result
+
+
+def fade_waveform(
+    waveform: np.ndarray,
+    fade_in_ms: float,
+    fade_out_ms: float,
+    *,
+    sample_rate: int,
+) -> np.ndarray:
+    """波形にフェードイン・フェードアウトを適用する。"""
+    n_samples = waveform.shape[0]
+    # フェードイン・フェードアウトのサンプル数
+    n_fade_in = round(fade_in_ms * sample_rate / 1000)
+    n_fade_out = round(fade_out_ms * sample_rate / 1000)
+    # フェードイン
+    if n_fade_in > 0:
+        waveform[:n_fade_in] *= np.linspace(0.0, 1.0, n_fade_in)[:n_samples] ** 2
+    # フェードアウト
+    if n_fade_out > 0:
+        waveform[-n_fade_out:] *= np.linspace(1.0, 0.0, n_fade_out)[-n_samples:] ** 2
+
+    return waveform
 
 def load_vocoder_model(
     model_dir: Path | str,

--- a/wavtool.py
+++ b/wavtool.py
@@ -19,11 +19,24 @@ wavtool の処理の流れ
 - 自身が 先頭ノート/中間ノート/最終ノート のいずれなのか不明なので、wav ファイルは常に出力必要。
 - wav ファイルを出力する際、既存の wav ファイルがある場合は、オーバーラップ時間を考慮して重ねる。
 
-"""
 
+UTAU から wavtool に渡されるコマンドの例
+-----------------------
+<tool> <output> <temp> <stp> <length> <envelope>
+-----------------------
+    tool   : wavtool.exe など実行ファイルのパス
+    output : 出力wavファイルパス
+    temp   : 入力wavファイルパス
+    stp    : 入力wav使用開始位置[ms]
+    length : ノート長さ[ms]
+    env    : 音量エンベロープのパラメータ (複数可)
+
+
+"""
 import argparse
 import logging
 import sys
+from copy import copy
 from functools import partial
 from math import ceil
 from pathlib import Path
@@ -80,10 +93,14 @@ def extract_overlap(envelope: list[float]) -> float:
     len_envelope = len(envelope)
     if len_envelope in [2, 7]:
         return 0.0
-    if len_envelope in [8, 9, 11]:
+    if len_envelope in [8, 9, 10, 11]:
         return envelope[7]
-    msg = f'Invalid envelope length ({len_envelope}). The length must be 2, 7, 8, 9, or 11.'
+    msg = (
+        f'Invalid envelope length ({len_envelope}). '
+        f'The length must be 2, 7, 8, 9, 10, or 11.: {envelope}'
+    )
     raise ValueError(msg)
+    # return 0.0
 
 
 def parse_envelope(
@@ -107,6 +124,7 @@ def parse_envelope(
     - 長さ7 : p1 p2 p3 v1 v2 v3 v4
     - 長さ8 : p1 p2 p3 v1 v2 v3 v4 ove
     - 長さ9 : p1 p2 p3 v1 v2 v3 v4 ove p4
+    - 長さ10: p1 p2 p3 v1 v2 v3 v4 ove p4 ?? ※詳細不明
     - 長さ11: p1 p2 p3 v1 v2 v3 v4 ove p4 p5 v5
     p1, p2, p3, p4, p5, ove : float (ms)
     v1, v2, v3, v4, v5 : int (1-200)
@@ -166,7 +184,8 @@ def parse_envelope(
         v_list = [0, v1, v2, v3, v4, 0]
         overlap = envelope[7]
     # 長さ9の時は p4 が追加される
-    elif len_envelope == 9:
+    # 長さが10の時は何が追加されているかよくわからない(0)ので、9と同じ処理をする
+    elif len_envelope in (9, 10):
         # [p1, p2, p3, v1, v2, v3, v4, ove, p4]
         p1, p2, p3 = envelope[0:3]
         v1, v2, v3, v4 = envelope[3:7]
@@ -203,7 +222,10 @@ def parse_envelope(
         v_list = [0, v1, v2, v5, v3, v4, 0]
     # それ以外の要素数はエラー
     else:
-        msg = f'Invalid envelope length ({len_envelope}). The length must be 2, 7, 8, 9, or 11.'
+        msg = (
+            f'Invalid envelope length ({len_envelope}). '
+            f'The length must be 2, 7, 8, 9, or 11.: {envelope}'
+        )
         raise ValueError(msg)
 
     # p_list が昇順になっていない場合はエラー
@@ -266,6 +288,8 @@ class NeuralNetworkWavTool:
     internal_sample_rate: int  # 内部処理のサンプルレート [Hz]
     target_sample_rate: int  # 出力wavのサンプルレート [Hz]
     resample_type: str  # リサンプリングの種類
+    # 出力用データ
+    _waveform: np.ndarray | None  # 出力wavの波形データ
     # 音量エンベロープ関連
     envelope_p: list[float]  # 音量エンベロープの時刻のリスト [ms]
     envelope_v: list[int]  # 音量エンベロープの音量値のリスト(0-100-200) [-]
@@ -368,7 +392,7 @@ class NeuralNetworkWavTool:
             self.vocoder_model = vocoder_model
             self.vocoder_in_scaler = vocoder_in_scaler
             self.vocoder_config = vocoder_config
-            self.logger.info('Using vocoder model: %s', self.use_vocoder_model)
+            self.logger.info(f'Using vocoder model: {self.use_vocoder_model}')
             # サンプルレートチェック
             if self.vocoder_config.data.sample_rate != self.internal_sample_rate:
                 msg = (
@@ -409,6 +433,20 @@ class NeuralNetworkWavTool:
     def fft_size(self) -> int:
         """FFTサイズ"""
         return pyworld.get_cheaptrick_fft_size(self.internal_sample_rate)  # pyright: ignore[reportAttributeAccessIssue]
+
+    @property
+    def waveform(self) -> np.ndarray:
+        """出力wavの波形データ"""
+        if self._waveform is None:
+            msg = 'self._waveform is None. Run generate_waveform() first.'
+            self.logger.error(msg)
+            raise ValueError(msg)
+        return self._waveform
+
+    @waveform.setter
+    def waveform(self, value: np.ndarray) -> None:
+        """出力wavの波形データをセットする。"""
+        self._waveform = value
 
     def __init_length(
         self, original_length: float, original_overlap: float, residual_error: float
@@ -526,14 +564,20 @@ class NeuralNetworkWavTool:
 
         TODO: 音量エンベロープの時刻と音量値に基づいて、spectrogram の音量加工を行う。
         """
-        self.logger.debug('envelope_p: %s', self.envelope_p)
+        n_frames = self.sp.shape[0]
+        self.logger.debug('envelope_p : %s', self.envelope_p)
+        self.logger.debug('envelope_v : %s', self.envelope_v)
+        self.logger.debug('sp.shape   : %s', self.sp.shape)
+        self.logger.debug('n_frames   : %s', n_frames)
         # エンベロープが2点以下の場合は何もしない
         if len(self.envelope_p) < 2:
             return
         # エンベロープが3点以上の場合は音量エンベロープを適用する
-        n_frames = self.f0.shape[0]
-        x = np.arange(n_frames)
+        x = np.arange(n_frames) + 0.5
         # 時刻をフレーム単位に変換
+        ## NOTE: 時刻(slice)でなくフレーム(index)で音量制御する都合上、
+        ## NOTE: xp の最大値を n_frames-1 にしないと終端フレームが0にならないので時刻補正必要。
+        ## TODO: 非常に短いノートではクロスフェード長がずれてしまう可能性があるため、フェードイン(p1,2,5)/アウト(p3,4)の時刻を別々に計算するなどの厳密な実装が必要。  # noqa: E501
         xp = [round(p / self.frame_period) for p in self.envelope_p]
         # 音量値(0-200)を0-2に正規化 (余った v は無視)
         fp = [v / 100.0 for v in self.envelope_v[: len(xp)]]
@@ -541,6 +585,11 @@ class NeuralNetworkWavTool:
         volume_envelope = np.interp(x, xp, fp)
         # sp に音量エンベロープを適用する。音量を x 倍するには sp を x^2 倍する。
         self.sp *= volume_envelope[:, np.newaxis] ** 2
+        self.logger.debug('x                    : %s', x)
+        self.logger.debug('xp                   : %s', xp)
+        self.logger.debug('fp                   : %s', fp)
+        self.logger.debug('volume_envelope      : %s', volume_envelope)
+        self.logger.debug('volume_envelope.shape: %s', volume_envelope.shape)
 
     def _apply_all(self) -> None:
         """self.f0, self.sp, self.ap に stp, length, envelope を適用する。
@@ -608,7 +657,7 @@ class NeuralNetworkWavTool:
 
         # overlap をフレーム数に変換
         n_overlap_frames = round(self.overlap / self.frame_period)
-        self.logger.info('overlap_frames: %s', n_overlap_frames)
+        self.logger.debug('overlap_frames: %s', n_overlap_frames)
 
         # デバッグ出力 --------------------------
         self.logger.debug('Features before overlap:')
@@ -661,16 +710,6 @@ class NeuralNetworkWavTool:
             self.logger.error(msg)
             raise ValueError(msg)
 
-        # npzファイルに書き出す
-        world_to_npzfile(
-            self.f0_appended,
-            self.sp_appended,
-            self.ap_appended,
-            self.internal_sample_rate,
-            self.output_npz,
-            compress=False,
-        )
-
         # ボコーダーモデルを使用しない場合
         if self.use_vocoder_model is False:
             # wav 生成
@@ -713,6 +752,34 @@ class NeuralNetworkWavTool:
             self.logger.error(msg)
             raise ValueError(msg)
 
+        self.waveform = wav
+
+    def save_npz(self) -> None:
+        """WORLD特徴量をnpzファイルで保存する。"""
+        # append された特徴量が揃っていることを確認する
+        if self.f0_appended is None or self.sp_appended is None or self.ap_appended is None:
+            msg = 'f0_appended, sp_appended, or ap_appended is None. Call append() first.'
+            self.logger.error(msg)
+            raise ValueError(msg)
+        # npzファイルに保存
+        world_to_npzfile(
+            self.f0_appended,
+            self.sp_appended,
+            self.ap_appended,
+            self.internal_sample_rate,
+            self.output_npz,
+        )
+        self.logger.info('Saved WORLD features to: %s', self.output_npz)
+
+    def save_wav(self) -> None:
+        """wavファイルを保存する。"""
+        # waveform が生成されていることを確認する
+        if self.waveform is None:
+            msg = 'waveform is None. Call synthesize() first.'
+            self.logger.error(msg)
+            raise ValueError(msg)
+        wav: np.ndarray = copy(self.waveform)
+
         # wavform の長さを丸め誤差分だけ補正する ----------------------------------------------
         # self._residual_error が正の場合、生成した波形が目標より短いので、ゼロパディング必要。
         # self._residual_error が負の場合、生成した波形が目標より長いので、切り詰め必要。
@@ -727,15 +794,16 @@ class NeuralNetworkWavTool:
             wav = wav[:n_compensation_samples]  # internal_sample_rate
         self.logger.debug('waveform.shape after compensation: %s', wav.shape)
         # -------------------------------------------------------------------------------------
-
-        # wavファイルに書き出す。
+        # wav ファイルに保存
         waveform_to_wavfile(
             wav,
             self.output_wav,
-            original_sample_rate=self.internal_sample_rate,
-            target_sample_rate=self.target_sample_rate,
+            self.internal_sample_rate,
+            self.target_sample_rate,
             resample_type=self.resample_type,
-        )  # target_sample_rate
+            dtype=wav.dtype,
+        )
+        self.logger.info('Saved wav to: %s', self.output_wav)
 
 
 # MARK: main_wavtool
@@ -816,8 +884,11 @@ def main_wavtool() -> None:
     )
     # wavtool で音声WORLD特徴量を結合
     wavtool.append()
-    # wav ファイルを生成
+    # wav データを生成
     wavtool.synthesize()
+    # npz と wav ファイルを保存
+    wavtool.save_npz()
+    wavtool.save_wav()
 
 
 if __name__ == '__main__':

--- a/wavtool.py
+++ b/wavtool.py
@@ -798,8 +798,8 @@ class NeuralNetworkWavTool:
         waveform_to_wavfile(
             wav,
             self.output_wav,
-            self.internal_sample_rate,
-            self.target_sample_rate,
+            original_sample_rate=self.internal_sample_rate,
+            target_sample_rate=self.target_sample_rate,
             resample_type=self.resample_type,
             dtype=wav.dtype,
         )

--- a/wavtool.py
+++ b/wavtool.py
@@ -100,7 +100,6 @@ def extract_overlap(envelope: list[float]) -> float:
         f'The length must be 2, 7, 8, 9, 10, or 11.: {envelope}'
     )
     raise ValueError(msg)
-    # return 0.0
 
 
 def parse_envelope(


### PR DESCRIPTION
## 実装内容
- 休符ごとに分割してレンダリングすることで VRAM 消費を抑制
- WAV を連続レンダリングする際に VRAM 消費が急激に増える不具合を修正 (`torch.cuda.empty_cache` で解放)
- wavtool に渡されるエンベロープの要素数 10 を許容するようにした。

## 既知の不具合
- 特定のUTAU音源にて、WAVの長さが短くなる不具合あり。丸め誤差の計算 (length, overlap, residual_error) に関連した不具合があると想定されるが、セグメント合成ではなく NeuralNetworkWavTool における不具合と思われる。別途修正必要。